### PR TITLE
Change read_delim na option to empty strings

### DIFF
--- a/R/readTable.R
+++ b/R/readTable.R
@@ -30,7 +30,8 @@ readTable <- function(path_to_table_file, table_type, delim=",") {
   table <- readr::read_delim(
     path_to_table_file,
     col_types = table_info$col_type[[1]],
-    delim =  delim
+    delim =  delim,
+    na = c("")
   )
 
   # if it has an ignore column take only selected values


### PR DESCRIPTION
This is for issue #11 

Now the `readr::read_delim` will only consider empty strings as NA but does not consider "NA" string.

https://github.com/FinOMOP/ROMOPMappingTools/blob/3ef5e7a58b6a11c7fe9c4104ff672868213b8311/R/readTable.R#L30-L35